### PR TITLE
Fixed enum short int width on arm-none-eabi

### DIFF
--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -81,8 +81,12 @@ typedef struct MotorCommandPacket {
 
 typedef enum MotorResponsePacketType {
     MRP_PARAMS,
-    MRP_MOTION
+    MRP_MOTION,
+    _MRP_FORCE_ENUM_TO_BE_4BYTES = 0xAA55CC33,
 } MotorResponsePacketType_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(MotorResponsePacketType_t) == 4, "Expected MotorResponsePacketType_t to have a size of 4");
+#endif
 
 typedef struct MotorResponse_Params_Packet {
     uint8_t version_major;
@@ -97,13 +101,6 @@ typedef struct MotorResponse_Params_Packet {
     PidValue_t cur_d;
     uint16_t cur_clamp;
     uint16_t reserved;
-
-    #if INTPTR_MAX == INT32_MAX
-    // this isn't 8 byte aligned, so reserve 4 trailing bytes on 32bit systems
-    // to manually bring padding into equality
-    // check with asserts
-    uint32_t reserved_8byte_alignment;
-    #endif
 } __attribute__((packed)) MotorResponse_Params_Packet_t;
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(MotorResponse_Params_Packet_t) == 36, "Expected MotorResponse_Params_Packet to have a size of 36");


### PR DESCRIPTION
This was found when integrating with stspin build system. Enum isn't a guaranteed size, so we force it now and add some checks. 

Looks like enums default to 2 bytes because int defaults to short int on arm-none-eabi systems, where as x86/x64 use 4 byte ints. This PR adds a static check to assumed enum width, and adds a dummy value to force width. 

It also removes padding I thought was necessary to force DWORD/QWORD alignment, but packed structs always report the packed size even if the system ABI guarentees QWORD alignment (the following 4 bytes is always padded, just not considered part of the struct). This is was backed up by the static checks and additional searching.