### PR TITLE
Update packets to latest spec

### DIFF
--- a/ateam-common-packets/include/basic_control.h
+++ b/ateam-common-packets/include/basic_control.h
@@ -19,6 +19,7 @@
 #endif
 
 typedef enum KickRequest {
+    KR_ARM,
     KR_DISABLE,
     KR_KICK_NOW,
     KR_KICK_TOUCH,
@@ -34,7 +35,7 @@ typedef struct BasicControl {
     float vel_z_angular; // m/s
     float kick_vel; // m/s (also applies to chips)
     float dribbler_speed; // rpm
-    uint8_t kick_request;
+    KickRequest_t kick_request;
 } BasicControl_t;
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(BasicControl_t) == 24, "Expected BasicControl_t to have a size of 24");

--- a/ateam-common-packets/include/basic_control.h
+++ b/ateam-common-packets/include/basic_control.h
@@ -1,0 +1,41 @@
+/**
+ * @file basic_control.h
+ * @author Matthew Barulic
+ * @brief definition for Basic Control data type
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+
+#pragma once
+
+#include <stdint.h>
+
+// if C11 or newer is used, include assert_static macro for testing
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#include <assert.h>
+#endif
+
+typedef enum KickRequest {
+    KR_DISABLE,
+    KR_KICK_NOW,
+    KR_KICK_TOUCH,
+    KR_KICK_CAPTURED,
+    KR_CHIP_NOW,
+    KR_CHIP_TOUCH,
+    KR_CHIP_CAPTURED
+} KickRequest_t;
+
+typedef struct BasicControl {
+    float vel_x_linear; // m/s
+    float vel_y_linear; // m/s
+    float vel_z_angular; // m/s
+    float kick_vel; // m/s (also applies to chips)
+    float dribbler_speed; // rpm
+    uint8_t kick_request;
+} BasicControl_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(BasicControl_t) == 24, "Expected BasicControl_t to have a size of 24");
+#endif

--- a/ateam-common-packets/include/basic_telemetry.h
+++ b/ateam-common-packets/include/basic_telemetry.h
@@ -1,0 +1,56 @@
+/**
+ * @file basic_telemetry.h
+ * @author Matthew Barulic
+ * @brief definition for Basic Telemetry data type
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+// if C11 or newer is used, include assert_static macro for testing
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#include <assert.h>
+#endif
+
+typedef struct BasicTelemetry {
+    uint16_t sequence_number;
+    uint8_t robot_revision_major;
+    uint8_t robot_revision_minor;
+    float battery_level; // volts
+    float battery_temperature; // deg C
+    uint32_t power_error : 1;
+    uint32_t tipped_error : 1;
+    uint32_t breakbeam_error : 1;
+    uint32_t breakbeam_ball_detected : 1;
+    uint32_t accelerometer_0_error : 1;
+    uint32_t accelerometer_1_error: 1;
+    uint32_t gyroscope_0_error : 1;
+    uint32_t gyroscope_1_error : 1;
+    uint32_t motor_0_general_error : 1;
+    uint32_t motor_0_hall_error : 1;
+    uint32_t motor_1_general_error : 1;
+    uint32_t motor_1_hall_error : 1;
+    uint32_t motor_2_general_error : 1;
+    uint32_t motor_2_hall_error : 1;
+    uint32_t motor_3_general_error : 1;
+    uint32_t motor_3_hall_error : 1;
+    uint32_t motor_4_general_error : 1;
+    uint32_t motor_4_hall_error : 1;
+    uint32_t chipper_available : 1;
+    uint32_t kicker_available : 1;
+    uint32_t reserved : 12;
+    float motor_0_temperature; // deg C
+    float motor_1_temperature; // deg C
+    float motor_2_temperature; // deg C
+    float motor_3_temperature; // deg C
+    float motor_4_temperature; // deg C
+    float kicker_charge_level;
+} BasicTelemetry_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(BasicTelemetry_t) == 40, "Expected BasicTelemetry_t to have a size of 40");
+#endif

--- a/ateam-common-packets/include/basic_telemetry.h
+++ b/ateam-common-packets/include/basic_telemetry.h
@@ -49,7 +49,7 @@ typedef struct BasicTelemetry {
     float motor_2_temperature; // deg C
     float motor_3_temperature; // deg C
     float motor_4_temperature; // deg C
-    float kicker_charge_level;
+    float kicker_charge_level; // volts
 } BasicTelemetry_t;
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(BasicTelemetry_t) == 40, "Expected BasicTelemetry_t to have a size of 40");

--- a/ateam-common-packets/include/hello_data.h
+++ b/ateam-common-packets/include/hello_data.h
@@ -27,7 +27,7 @@ static_assert(sizeof(TeamColor_t) == 1, "Expected TeamColor_t to have a size of 
 
 typedef struct HelloData {
     uint8_t robot_id;
-    TeamColor color;
+    TeamColor_t color;
 } HelloData_t;
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(HelloData_t) == 2, "Expected HelloData_t to have a size of 2");

--- a/ateam-common-packets/include/hello_data.h
+++ b/ateam-common-packets/include/hello_data.h
@@ -1,0 +1,34 @@
+/**
+ * @file hello_data.h
+ * @author Matthew Barulic
+ * @brief definition for Hello Data data type
+ * @version 0.1
+ * 
+ * @copyright Copyright (c) 2022
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+// if C11 or newer is used, include assert_static macro for testing
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+#include <assert.h>
+#endif
+
+typedef enum TeamColor : unsigned char {
+    TC_YELLOW = 0,
+    TC_BLUE = 1
+} TeamColor_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(TeamColor_t) == 1, "Expected TeamColor_t to have a size of 1");
+#endif
+
+typedef struct HelloData {
+    uint8_t robot_id;
+    TeamColor color;
+} HelloData_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(HelloData_t) == 2, "Expected HelloData_t to have a size of 2");
+#endif

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -17,34 +17,49 @@
 #include <assert.h>
 #endif
 
+const uint16_t kProtocolVersionMajor = 0;
+const uint16_t kProtocolVersionMinor = 0;
+
+typedef enum CommandCode : unsigned char {
+    CC_ACK = 1,
+    CC_NACK = 2,
+    CC_GOODBYE = 3,
+    CC_HELLO = 101,
+    CC_TELEMETRY = 102,
+    CC_CONTROL = 201
+} CommandCode_t;
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+static_assert(sizeof(CommandCode_t) == 1, "Expected CommandCode_t to have a size of 1");
+#endif 
+
 typedef enum DataType : unsigned char {
-    ROBOT_MOTION_COMMAND,
-    ROBOT_DEBUG
+    DT_NO_DATA = 0,
+    DT_HELLO_DATA = 1,
+    DT_BASIC_TELEMETRY = 2,
+    DT_BASIC_CONTROL = 3
 } DataType_t;  
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(DataType_t) == 1, "Expected DataType_t to have a size of 1");
-#endif  
+#endif
 
 /**
  * @brief A single packet to be sent over the network (via UDP)
  * 
- * @param major_version : uint8_t  : Major version number of API
- * @param minor_version : uint8_t  : Minor version number of API
- * @param patch_version : uint16_t : Patch version number of API
+ * @param major_version : uint16_t  : Major version number of protocol
+ * @param minor_version : uint16_t  : Minor version number of protocol
  * @param command_code  : uint8_t  : Code describing data, see radio-protocol/README
  * @param data_type     : DataType : Type of message data
  * @param data_size     : uint16_t : Size of data in bytes
- * @param data          : void*    : Buffer containing data to send
+ * @param data          : uint8_t[500]    : Buffer containing data to send
  * 
  */
 typedef struct RadioPacket {
-    uint8_t major_version : 1;
-    uint8_t minor_version : 1;
-    uint16_t patch_version : 2;
-    uint8_t command_code : 1;
-    DataType data_type;
-    uint16_t data_length : 2;
-    void* data;
+    uint16_t major_version;
+    uint16_t minor_version;
+    CommandCode_t command_code;
+    DataType_t data_type;
+    uint16_t data_length;
+    uint8_t data[500];
 } RadioPacket_t;
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 static_assert(sizeof(RadioPacket_t) <= 508, "Expected RadioPacket_t to have a size <= 508");

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -24,6 +24,7 @@ typedef enum CommandCode : unsigned char {
     CC_ACK = 1,
     CC_NACK = 2,
     CC_GOODBYE = 3,
+    CC_KEEPALIVE = 4,
     CC_HELLO = 101,
     CC_TELEMETRY = 102,
     CC_CONTROL = 201

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -13,6 +13,10 @@ fn main() {
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
+        .header("../include/basic_control.h")
+        .header("../include/basic_telemetry.h")
+        .header("../include/hello_data.h")
+        .header("../include/radio.h")
         .header("../include/stspin.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.

--- a/radio-protocol/README
+++ b/radio-protocol/README
@@ -1,4 +1,6 @@
-Robot Networking Protocol Specification
+# Robot Networking Protocol Specification
+
+<span style="color:red">**NOTE:**</span> This specification is being collaboratively updated [here](https://docs.google.com/document/d/1O09lvcoexoYhVQzl3QtoxvIDNEamm63JrjVRY-vIe3Q). The content below may not reflect latest spec or implementation.
 
 This is a specification of a basic protocol for communication between RoboCup robots and a control server. 
 Robot-robot communication is not supported. Multiple control servers are not supported. This specification assumes only friendly devices will be present on the network.


### PR DESCRIPTION
Updated the packet structs to match the current spec doc as I start implementing the radio bridge node.

Note: enum name prefixes (ie. `DT_*`) are to help avoid name conflicts with common macros / global names. We're mulling over converting these headers to C++ to get better name spacing tools.