### PR TITLE
Fxi Type Generation on Bindgen

### DIFF
--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -25,8 +25,8 @@
 typedef float PidValue_t;
 
 typedef enum MotorCommandPacketType {
-    MCP_PARAMS,
-    MCP_MOTION
+    MCP_PARAMS = 0,
+    MCP_MOTION = 1
 } MotorCommandPacketType_t;
 
 typedef struct MotorCommand_Params_Packet {

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -11,6 +11,8 @@ fn main() {
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
+        .use_core()
+        .ctypes_prefix("::core::ffi")
         // The input header we would like to generate
         // bindings for.
         .header("../include/stspin.h")

--- a/ateam-common-packets/rust-lib/src/lib.rs
+++ b/ateam-common-packets/rust-lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/ateam-common-packets/rust-lib/src/lib.rs
+++ b/ateam-common-packets/rust-lib/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![feature(core_ffi_c)]
 
 pub mod stspin_packets {
 	include!("stspin_bindings.rs");

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             clang
 
             # Rust Embedded
-            rust-bin.stable.latest.default
+            rust-bin.nightly.latest.default.override
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
             clang
 
             # Rust Embedded
-            rust-bin.nightly.latest.default.override
+            rust-bin.nightly.latest.default
           ];
         };
       }


### PR DESCRIPTION
By default bindgen exports stdlib type, but embedded targets don't have std by default. Change types to core types, and mark crate as no_std.