### PR TITLE
Will/motor response packet alignment hotfix

### DIFF
--- a/ateam-common-packets/include/basic_control.h
+++ b/ateam-common-packets/include/basic_control.h
@@ -8,15 +8,9 @@
  *
  */
 
-
 #pragma once
 
-#include <stdint.h>
-
-// if C11 or newer is used, include assert_static macro for testing
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-#include <assert.h>
-#endif
+#include "common.h"
 
 typedef enum KickRequest {
     KR_ARM,
@@ -27,7 +21,7 @@ typedef enum KickRequest {
     KR_CHIP_NOW,
     KR_CHIP_TOUCH,
     KR_CHIP_CAPTURED
-} KickRequest_t;
+} KickRequest;
 
 typedef struct BasicControl {
     float vel_x_linear; // m/s
@@ -35,8 +29,6 @@ typedef struct BasicControl {
     float vel_z_angular; // m/s
     float kick_vel; // m/s (also applies to chips)
     float dribbler_speed; // rpm
-    KickRequest_t kick_request;
-} BasicControl_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(BasicControl_t) == 24, "Expected BasicControl_t to have a size of 24");
-#endif
+    KickRequest kick_request;
+} BasicControl;
+assert_size(BasicControl, 24);

--- a/ateam-common-packets/include/basic_telemetry.h
+++ b/ateam-common-packets/include/basic_telemetry.h
@@ -10,12 +10,7 @@
 
 #pragma once
 
-#include <stdint.h>
-
-// if C11 or newer is used, include assert_static macro for testing
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-#include <assert.h>
-#endif
+#include "common.h"
 
 typedef struct BasicTelemetry {
     uint16_t sequence_number;
@@ -50,7 +45,5 @@ typedef struct BasicTelemetry {
     float motor_3_temperature; // deg C
     float motor_4_temperature; // deg C
     float kicker_charge_level; // volts
-} BasicTelemetry_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(BasicTelemetry_t) == 40, "Expected BasicTelemetry_t to have a size of 40");
-#endif
+} BasicTelemetry;
+assert_size(BasicTelemetry, 40);

--- a/ateam-common-packets/include/common.h
+++ b/ateam-common-packets/include/common.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+
+#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+    #if defined(__ARM_ARCH_7EM__)
+        #define static_assert _Static_assert
+    #else
+        #include <assert.h>
+    #endif
+#else
+    #define static_assert(args...)
+#endif
+
+#define assert_size(type, size) static_assert(sizeof(type) == size, "Expected " #type " to have a size of " #size)
+
+// This is only used for generating an error that shows the actual size of given type
+#define error_size(type) static_assert((char[sizeof(type)])"");

--- a/ateam-common-packets/include/hello_data.h
+++ b/ateam-common-packets/include/hello_data.h
@@ -10,25 +10,16 @@
 
 #pragma once
 
-#include <stdint.h>
+#include "common.h"
 
-// if C11 or newer is used, include assert_static macro for testing
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-#include <assert.h>
-#endif
-
-typedef enum TeamColor : unsigned char {
+typedef enum TeamColor : uint8_t {
     TC_YELLOW = 0,
     TC_BLUE = 1
-} TeamColor_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(TeamColor_t) == 1, "Expected TeamColor_t to have a size of 1");
-#endif
+} TeamColor;
+assert_size(TeamColor, 1);
 
 typedef struct HelloData {
     uint8_t robot_id;
-    TeamColor_t color;
-} HelloData_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(HelloData_t) == 2, "Expected HelloData_t to have a size of 2");
-#endif
+    TeamColor color;
+} HelloData;
+assert_size(HelloData, 2);

--- a/ateam-common-packets/include/hello_data.h
+++ b/ateam-common-packets/include/hello_data.h
@@ -18,8 +18,14 @@ typedef enum TeamColor : uint8_t {
 } TeamColor;
 assert_size(TeamColor, 1);
 
-typedef struct HelloData {
+typedef struct HelloRequest {
     uint8_t robot_id;
     TeamColor color;
-} HelloData;
-assert_size(HelloData, 2);
+} HelloRequest;
+assert_size(HelloRequest, 2);
+
+typedef struct HelloResponse {
+    uint8_t ipv4[4];
+    uint16_t port;
+} HelloResponse;
+assert_size(HelloResponse, 6);

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -35,6 +35,7 @@ typedef struct RadioPacket {
     uint16_t major_version;
     uint16_t minor_version;
     CommandCode command_code;
+    uint16_t data_length;
     union Data {
         HelloRequest hello_request;
         HelloResponse hello_response;

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -10,17 +10,15 @@
 
 #pragma once
 
-#include <stdint.h>
-
-// if C11 or newer is used, include assert_static macro for testing
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-#include <assert.h>
-#endif
+#include "common.h"
+#include "hello_data.h"
+#include "basic_control.h"
+#include "basic_telemetry.h"
 
 const uint16_t kProtocolVersionMajor = 0;
 const uint16_t kProtocolVersionMinor = 0;
 
-typedef enum CommandCode : unsigned char {
+typedef enum CommandCode : uint8_t {
     CC_ACK = 1,
     CC_NACK = 2,
     CC_GOODBYE = 3,
@@ -28,40 +26,18 @@ typedef enum CommandCode : unsigned char {
     CC_HELLO = 101,
     CC_TELEMETRY = 102,
     CC_CONTROL = 201
-} CommandCode_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(CommandCode_t) == 1, "Expected CommandCode_t to have a size of 1");
-#endif 
+} CommandCode;
+assert_size(CommandCode, 1);
 
-typedef enum DataType : unsigned char {
-    DT_NO_DATA = 0,
-    DT_HELLO_DATA = 1,
-    DT_BASIC_TELEMETRY = 2,
-    DT_BASIC_CONTROL = 3
-} DataType_t;  
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(DataType_t) == 1, "Expected DataType_t to have a size of 1");
-#endif
-
-/**
- * @brief A single packet to be sent over the network (via UDP)
- * 
- * @param major_version : uint16_t  : Major version number of protocol
- * @param minor_version : uint16_t  : Minor version number of protocol
- * @param command_code  : uint8_t  : Code describing data, see radio-protocol/README
- * @param data_type     : DataType : Type of message data
- * @param data_size     : uint16_t : Size of data in bytes
- * @param data          : uint8_t[500]    : Buffer containing data to send
- * 
- */
 typedef struct RadioPacket {
+    uint32_t crc32;
     uint16_t major_version;
     uint16_t minor_version;
-    CommandCode_t command_code;
-    DataType_t data_type;
-    uint16_t data_length;
-    uint8_t data[500];
-} RadioPacket_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(RadioPacket_t) <= 508, "Expected RadioPacket_t to have a size <= 508");
-#endif
+    CommandCode command_code;
+    union ResponseData {
+        HelloData hello;
+        BasicControl control;
+        BasicTelemetry telemetry;
+    } data;
+} RadioPacket;
+assert_size(RadioPacket, 52);

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -23,9 +23,10 @@ typedef enum CommandCode : uint8_t {
     CC_NACK = 2,
     CC_GOODBYE = 3,
     CC_KEEPALIVE = 4,
-    CC_HELLO = 101,
+    CC_HELLO_REQ = 101,
     CC_TELEMETRY = 102,
-    CC_CONTROL = 201
+    CC_CONTROL = 201,
+    CC_HELLO_RESP = 202,
 } CommandCode;
 assert_size(CommandCode, 1);
 
@@ -34,10 +35,11 @@ typedef struct RadioPacket {
     uint16_t major_version;
     uint16_t minor_version;
     CommandCode command_code;
-    union ResponseData {
-        HelloData hello;
+    union Data {
+        HelloRequest hello_request;
+        HelloResponse hello_response;
         BasicControl control;
         BasicTelemetry telemetry;
-    } data;
+    } data __attribute__((aligned (4)));
 } RadioPacket;
 assert_size(RadioPacket, 52);

--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -15,25 +15,12 @@
 
 #pragma once
 
-#include <stdint.h>
-
-// if C11 or newer is used, include assert_static macro for testing
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L) && !defined(__ARM_ARCH_7EM__)
-    #if defined(__ARM_ARCH_7EM__)
-        #define static_assert(args...) _Static_assert(args...)
-    #else
-        #include <assert.h>
-    #endif
-#else
-    #define static_assert(args...)
-#endif
-
-typedef float PidValue_t;
+#include "common.h"
 
 typedef enum MotorCommandPacketType {
     MCP_PARAMS = 0,
     MCP_MOTION = 1
-} MotorCommandPacketType_t;
+} MotorCommandPacketType;
 
 typedef struct MotorCommand_Params_Packet {
     uint32_t update_timestamp : 1;
@@ -50,64 +37,53 @@ typedef struct MotorCommand_Params_Packet {
     uint32_t reserved : 22;
 
     uint32_t timestamp;
-    PidValue_t vel_p;
-    PidValue_t vel_i;
-    PidValue_t vel_d;
-    PidValue_t vel_i_max;
-    PidValue_t cur_p;
-    PidValue_t cur_i;
-    PidValue_t cur_d;
-    PidValue_t cur_i_max;
+    float vel_p;
+    float vel_i;
+    float vel_d;
+    float vel_i_max;
+    float cur_p;
+    float cur_i;
+    float cur_d;
+    float cur_i_max;
     uint16_t cur_clamp;
     // add future params here
-} MotorCommand_Params_Packet_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorCommand_Params_Packet_t) == 44, "Expected MotorCommand_Params_Packet_t to have a size of 44");
-#endif
+} MotorCommand_Params_Packet;
+assert_size(MotorCommand_Params_Packet, 44);
 
 typedef enum MotorCommand_MotionType {
     OPEN_LOOP = 0,
     VELOCITY = 1,
     TORQUE = 2,
     BOTH= 3
-} MotorCommand_MotionType_t;
+} MotorCommand_MotionType;
 
 typedef struct MotorCommand_Motion_Packet {
     uint32_t reset : 1;
     uint32_t enable_telemetry: 1;
     uint32_t reserved : 30;
-    MotorCommand_MotionType_t motion_control_type;
-
+    MotorCommand_MotionType motion_control_type;
     float setpoint;
-} MotorCommand_Motion_Packet_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorCommand_Motion_Packet_t) == 12, "Expected MotorCommand_Motion_Packet_t to have a size of 8");
-#endif
+} MotorCommand_Motion_Packet;
+assert_size(MotorCommand_Motion_Packet, 12);
 
 typedef struct MotorCommandPacket {
-    MotorCommandPacketType_t type;
+    MotorCommandPacketType type;
     uint32_t crc32;
-    union {
-        MotorCommand_Params_Packet_t params;
-        MotorCommand_Motion_Packet_t motion;
-    };
-} MotorCommandPacket_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorCommandPacket_t) == 52, "Expected MotorCommandPacket_t to have a size of 52");
-#endif
+    union CommandData {
+        MotorCommand_Params_Packet params;
+        MotorCommand_Motion_Packet motion;
+    } data __attribute__((aligned (4)));
+} MotorCommandPacket;
+assert_size(MotorCommandPacket, 52);
 
 /////////////////
 //  responses  //
 /////////////////
 
-typedef enum MotorResponsePacketType {
+typedef enum MotorResponsePacketType : uint8_t {
     MRP_PARAMS,
     MRP_MOTION,
-    _MRP_FORCE_ENUM_TO_BE_4BYTES = 0xAA55CC33,
-} MotorResponsePacketType_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorResponsePacketType_t) == 4, "Expected MotorResponsePacketType_t to have a size of 4");
-#endif
+} MotorResponsePacketType;
 
 typedef struct MotorResponse_Params_Packet {
     uint8_t version_major;
@@ -115,22 +91,20 @@ typedef struct MotorResponse_Params_Packet {
     uint16_t version_patch;
     uint32_t timestamp;
 
-    PidValue_t vel_p;
-    PidValue_t vel_i;
-    PidValue_t vel_d;
-    PidValue_t vel_i_max;
-    PidValue_t cur_p;
-    PidValue_t cur_i;
-    PidValue_t cur_d;
-    PidValue_t torque_i_max;
+    float vel_p;
+    float vel_i;
+    float vel_d;
+    float vel_i_max;
+    float cur_p;
+    float cur_i;
+    float cur_d;
+    float torque_i_max;
     uint16_t cur_clamp;
 
     uint16_t git_dirty: 1;
     uint16_t reserved: 15;
-} __attribute__((packed)) MotorResponse_Params_Packet_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorResponse_Params_Packet_t) == 44, "Expected MotorResponse_Params_Packet to have a size of 44");
-#endif
+} __attribute__((packed)) MotorResponse_Params_Packet;
+assert_size(MotorResponse_Params_Packet, 44);
 
 typedef struct MotorResponse_Motion_Packet {
     uint32_t master_error : 1;
@@ -161,19 +135,15 @@ typedef struct MotorResponse_Motion_Packet {
     float current_estimate;
     float current_computed_error;
     float current_computed_setpoint;
-} __attribute__((packed)) MotorResponse_Motion_Packet_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorResponse_Motion_Packet_t) == 48, "Expected MotorResponse_Motion_Packet to have a size of 48");
-#endif
+} __attribute__((packed)) MotorResponse_Motion_Packet;
+assert_size(MotorResponse_Motion_Packet, 48);
 
 typedef struct MotorResponsePacket {
-    MotorResponsePacketType_t type;
+    MotorResponsePacketType type;
     uint32_t crc32;
-    union {
-        MotorResponse_Params_Packet_t params;
-        MotorResponse_Motion_Packet_t motion;
-    };
-} __attribute__((packed)) MotorResponsePacket_t;
-#if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-static_assert(sizeof(MotorResponsePacket_t) == 56, "Expected MotorResponsePacket to have a size of 56");
-#endif
+    union ResponseData {
+        MotorResponse_Params_Packet params;
+        MotorResponse_Motion_Packet motion;
+    } data __attribute__((aligned (4)));
+} __attribute__((packed)) MotorResponsePacket;
+assert_size(MotorResponsePacket, 56);

--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -109,20 +109,25 @@ typedef struct MotorResponse_Params_Packet {
 assert_size(MotorResponse_Params_Packet, 44);
 
 typedef struct MotorResponse_Motion_Packet {
-    uint32_t master_error : 1;
-    uint32_t hall_power_error : 1;
-    uint32_t hall_disconnected_error : 1;
-    uint32_t bldc_transition_error : 1;
-    uint32_t bldc_commutation_watchdog_error : 1;
-    uint32_t enc_disconnected_error: 1;
-    uint32_t enc_decoding_error : 1;
-    uint32_t hall_enc_vel_disagreement_error: 1;
-    uint32_t overcurrent_error : 1;
-    uint32_t undervoltage_error : 1;
-    uint32_t overvoltage_error : 1;
-    uint32_t torque_limited : 1;
-    uint32_t control_loop_time_error: 1;
-    uint32_t reserved : 19;
+    uint8_t master_error : 1;
+    uint8_t hall_power_error : 1;
+    uint8_t hall_disconnected_error : 1;
+    uint8_t bldc_transition_error : 1;
+    uint8_t bldc_commutation_watchdog_error : 1;
+    uint8_t enc_disconnected_error: 1;
+    uint8_t enc_decoding_error : 1;
+    uint8_t hall_enc_vel_disagreement_error: 1;
+    uint8_t overcurrent_error : 1;
+    uint8_t undervoltage_error : 1;
+    uint8_t overvoltage_error : 1;
+    uint8_t torque_limited : 1;
+    uint8_t control_loop_time_error: 1;
+    uint8_t reset_watchdog_independent: 1;
+    uint8_t reset_watchdog_window: 1;
+    uint8_t reset_low_power: 1;
+    uint8_t reset_software: 1;
+    uint8_t reset_pin: 1;
+    uint32_t reserved : 14;
 
     uint32_t timestamp;
 

--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -20,7 +20,8 @@
 typedef enum MotorCommandPacketType {
     MCP_PARAMS = 0,
     MCP_MOTION = 1
-} MotorCommandPacketType;
+} __attribute__((packed)) MotorCommandPacketType;
+assert_size(MotorCommandPacketType, 1);
 
 typedef struct MotorCommand_Params_Packet {
     uint32_t update_timestamp : 1;
@@ -80,10 +81,11 @@ assert_size(MotorCommandPacket, 52);
 //  responses  //
 /////////////////
 
-typedef enum MotorResponsePacketType : uint8_t {
+typedef enum MotorResponsePacketType {
     MRP_PARAMS,
     MRP_MOTION,
-} MotorResponsePacketType;
+} __attribute__((packed)) MotorResponsePacketType;
+assert_size(MotorResponsePacketType, 1);
 
 typedef struct MotorResponse_Params_Packet {
     uint8_t version_major;

--- a/ateam-common-packets/include/stspin.h
+++ b/ateam-common-packets/include/stspin.h
@@ -146,8 +146,8 @@ typedef struct MotorResponse_Motion_Packet {
 assert_size(MotorResponse_Motion_Packet, 48);
 
 typedef struct MotorResponsePacket {
-    MotorResponsePacketType type;
-    uint32_t crc32;
+    MotorResponsePacketType type __attribute__((aligned (4)));
+    uint32_t crc32 __attribute__((aligned (4)));
     union ResponseData {
         MotorResponse_Params_Packet params;
         MotorResponse_Motion_Packet motion;

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -1,38 +1,61 @@
 extern crate bindgen;
-
-use std::fs;
-use std::path::PathBuf;
+use bindgen::EnumVariation;
+use std::path::Path;
 
 fn main() {
     // Tell cargo to invalidate the built crate whenever the sources change
     println!("cargo:rerun-if-changed=../include/");
 
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let bindings_stspin = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("../include/stspin.h")
+        .allowlist_file(".*/stspin.h")
+        // Tell bindgen to use core instead of std
         .use_core()
         .ctypes_prefix("::core::ffi")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Put enum consts in module
+        .default_enum_style(EnumVariation::ModuleConsts)
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate STSPIN bindings");
+
+    let bindings_radio = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("../include/basic_control.h")
         .header("../include/basic_telemetry.h")
         .header("../include/hello_data.h")
         .header("../include/radio.h")
-        .header("../include/stspin.h")
+        .allowlist_file(".*/basic_control.h")
+        .allowlist_file(".*/basic_telemetry.h")
+        .allowlist_file(".*/hello_data.h")
+        .allowlist_file(".*/radio.h")
+        .generate_comments(true)
+        // Tell bindgen to use core instead of std
+        .use_core()
+        .ctypes_prefix("::core::ffi")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Put enum consts in module
+        .default_enum_style(EnumVariation::ModuleConsts)
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
+        .expect("Unable to generate Radio bindings");
 
     // Write the bindings to the lib source dir
-    let src_dir = "src";
-    fs::create_dir_all(src_dir).expect("Failed to create src dir.");
-
-    let out_path = PathBuf::from(src_dir);
-    bindings.write_to_file(out_path.join("stspin_bindings.rs"))
+    // let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = "src";
+    bindings_stspin
+        .write_to_file(Path::new(&out_dir).join("bindings_stspin.rs"))
         .expect("Couldn't write STSPIN packet bindings!");
+    bindings_radio
+        .write_to_file(Path::new(&out_dir).join("bindings_radio.rs"))
+        .expect("Couldn't write Radio packet bindings!");
 }

--- a/ateam-common-packets/rust-lib/src/.gitignore
+++ b/ateam-common-packets/rust-lib/src/.gitignore
@@ -1,1 +1,1 @@
-bindings_*.rs
+*bindings*.rs

--- a/ateam-common-packets/rust-lib/src/.gitignore
+++ b/ateam-common-packets/rust-lib/src/.gitignore
@@ -1,3 +1,1 @@
-*.rs
-**/*.rs
-!lib.rs
+bindings_*.rs

--- a/ateam-common-packets/rust-lib/src/lib.rs
+++ b/ateam-common-packets/rust-lib/src/lib.rs
@@ -2,9 +2,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-#![feature(core_ffi_c)]
 
-pub mod stspin_packets {
-	include!("stspin_bindings.rs");
-}
-
+pub mod bindings_radio;
+pub mod bindings_stspin;

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657732321,
-        "narHash": "sha256-4t6lwx2edSYrZwtDAM+bUOze4Pra4v/mdWI5w/WICFw=",
+        "lastModified": 1678314140,
+        "narHash": "sha256-B91P+zQbxc0vi72cexRbcaYak00qVGtEbiRnmfG/mdI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bee8b6b38900aece7cb6d0908e64d98813e2bf5a",
+        "rev": "94c379180a50d0e915bb49a9d567ecc4d3fb548b",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1657680648,
-        "narHash": "sha256-UkH8lVSlNX22apOqnuyEtQPtuhL+XOPWQVG5dsgLamA=",
+        "lastModified": 1678242776,
+        "narHash": "sha256-36K1Rg2vM+NLqORSBL4e3aZHmgkb6aS9upHsuG4Akns=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3034ea450bdd5c2f7d9a8b2d7fd7c258f09113e7",
+        "rev": "ea311f10a5d51e7588799281bab0556b4e978d00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
enum field is undercontrained with packing across 32bit/64bit systems. These directives fix that.