### PR TITLE
added kicker packets

### DIFF
--- a/ateam-common-packets/include/basic_control.h
+++ b/ateam-common-packets/include/basic_control.h
@@ -11,17 +11,7 @@
 #pragma once
 
 #include "common.h"
-
-typedef enum KickRequest {
-    KR_ARM,
-    KR_DISABLE,
-    KR_KICK_NOW,
-    KR_KICK_TOUCH,
-    KR_KICK_CAPTURED,
-    KR_CHIP_NOW,
-    KR_CHIP_TOUCH,
-    KR_CHIP_CAPTURED
-} KickRequest;
+#include "kicker.h"
 
 typedef struct BasicControl {
     float vel_x_linear; // m/s

--- a/ateam-common-packets/include/kicker.h
+++ b/ateam-common-packets/include/kicker.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "common.h"
+
+typedef enum KickRequest {
+    KR_ARM,
+    KR_DISABLE,
+    KR_KICK_NOW,
+    KR_KICK_TOUCH,
+    KR_KICK_CAPTURED,
+    KR_CHIP_NOW,
+    KR_CHIP_TOUCH,
+    KR_CHIP_CAPTURED
+} KickRequest;
+
+typedef struct KickerControl {
+    uint32_t enable_charging: 1;
+    uint32_t flag_kick: 1;
+    uint32_t flag_chip: 1;
+    uint32_t flag_power_down: 1;
+    // 28 bits reserved
+    
+    float kick_speed;
+} KickerControl;
+assert_size(KickerControl, 8);
+
+typedef struct KickerTelemetry {
+    uint32_t powered_down: 1;
+    uint32_t ball_detected: 1;
+    uint32_t error_detected: 1;
+    // 29 bits reserved
+
+    float rail_voltage;
+    float battery_voltage;
+} KickerTelemetry;
+assert_size(KickerTelemetry, 12);

--- a/ateam-common-packets/include/kicker.h
+++ b/ateam-common-packets/include/kicker.h
@@ -15,14 +15,13 @@ typedef enum KickRequest {
 
 typedef struct KickerControl {
     uint32_t enable_charging: 1;
-    uint32_t flag_kick: 1;
-    uint32_t flag_chip: 1;
     uint32_t flag_power_down: 1;
-    // 28 bits reserved
-    
+    // 30 bits reserved
+
+    KickRequest kick_request;
     float kick_speed;
 } KickerControl;
-assert_size(KickerControl, 8);
+assert_size(KickerControl, 12);
 
 typedef struct KickerTelemetry {
     uint32_t powered_down: 1;

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -24,6 +24,24 @@ fn main() {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate STSPIN bindings");
 
+    let bindings_kicker = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("../include/kicker.h")
+        .allowlist_file(".*/kicker.h")
+        // Tell bindgen to use core instead of std
+        .use_core()
+        .ctypes_prefix("::core::ffi")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Put enum consts in module
+        .default_enum_style(EnumVariation::ModuleConsts)
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate Kicker bindings");
+
     let bindings_radio = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
@@ -55,6 +73,9 @@ fn main() {
     bindings_stspin
         .write_to_file(Path::new(&out_dir).join("bindings_stspin.rs"))
         .expect("Couldn't write STSPIN packet bindings!");
+    bindings_kicker
+        .write_to_file(Path::new(&out_dir).join("bindings_kicker.rs"))
+        .expect("Couldn't write Kicker packet bindings!");
     bindings_radio
         .write_to_file(Path::new(&out_dir).join("bindings_radio.rs"))
         .expect("Couldn't write Radio packet bindings!");

--- a/ateam-common-packets/rust-lib/src/lib.rs
+++ b/ateam-common-packets/rust-lib/src/lib.rs
@@ -3,5 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+pub mod bindings_kicker;
 pub mod bindings_radio;
 pub mod bindings_stspin;


### PR DESCRIPTION
adds packets for control <-> kicker communications. In the event these get passed up the stack, we default to a C header definition and we run bindgen on it