### PR TITLE
Merge Competition Code

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   test-firmware-build:
-    runs-on: [ubuntu-20.04, ubuntu-22.04, macos-latest]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: cachix/install-nix-action@v16

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   test-firmware-build:
-    runs-on: ubuntu-20.04
+    runs-on: [ubuntu-20.04, ubuntu-22.04, macos-latest]
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: cachix/install-nix-action@v16
@@ -18,6 +18,10 @@ jobs:
           nix flake check
           nix develop -c cargo --version
       - name: Build Common Items
+        shell: bash
+        run: |
+          nix develop -c make bindgen-packets
+      - name: Test Common Items
         shell: bash
         run: |
           nix develop -c make bindgen-packets-test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,11 +25,3 @@ jobs:
         shell: bash
         run: |
           nix develop -c make bindgen-packets-test
-      - name: Check Nightly
-        shell: bash
-        run: |
-          nix flake update
-          nix flake check
-          nix develop -c cargo update --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
-          nix develop -c cargo test --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
-          nix develop -c cargo --version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,4 +25,11 @@ jobs:
         shell: bash
         run: |
           nix develop -c make bindgen-packets-test
-
+      - name: Check Nightly
+        shell: bash
+        run: |
+          nix flake update
+          nix flake check
+          nix develop -c cargo update --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
+          nix develop -c cargo test --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
+          nix develop -c cargo --version

--- a/.github/workflows/WeeklyCheckOfRustNightly.yml
+++ b/.github/workflows/WeeklyCheckOfRustNightly.yml
@@ -1,0 +1,21 @@
+name: A-Team Common Upstream Check
+on:
+  schedule:
+    - cron: "0 0 * * FRI"
+jobs:
+  test-firmware-against-latest-nightly:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config:
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Run Tests
+        shell: bash
+        run: |
+          nix flake update
+          nix flake check
+          nix develop -c cargo update --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
+          nix develop -c cargo test --manifest-path=ateam-common-packets/rust-lib/Cargo.toml
+          nix develop -c cargo --version

--- a/ateam-common-packets/include/common.h
+++ b/ateam-common-packets/include/common.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 
 #if defined(__cplusplus) || (defined( __STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-    #if defined(__ARM_ARCH_7EM__)
+    #if defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_6M__)
         #define static_assert _Static_assert
     #else
         #include <assert.h>

--- a/ateam-common-packets/include/kicker.h
+++ b/ateam-common-packets/include/kicker.h
@@ -14,9 +14,10 @@ typedef enum KickRequest {
 } KickRequest;
 
 typedef struct KickerControl {
+    uint32_t telemetry_enabled: 1;
     uint32_t enable_charging: 1;
-    uint32_t flag_power_down: 1;
-    // 30 bits reserved
+    uint32_t request_power_down: 1;
+    // 29 bits reserved
 
     KickRequest kick_request;
     float kick_speed;
@@ -24,10 +25,11 @@ typedef struct KickerControl {
 assert_size(KickerControl, 12);
 
 typedef struct KickerTelemetry {
-    uint32_t powered_down: 1;
+    uint32_t power_down_requested: 1;
+    uint32_t power_down_complete: 1;
     uint32_t ball_detected: 1;
     uint32_t error_detected: 1;
-    // 29 bits reserved
+    // 28 bits reserved
 
     float rail_voltage;
     float battery_voltage;

--- a/ateam-common-packets/include/radio.h
+++ b/ateam-common-packets/include/radio.h
@@ -30,6 +30,24 @@ typedef enum CommandCode : uint8_t {
 } CommandCode;
 assert_size(CommandCode, 1);
 
+typedef struct RadioHeader {
+    uint32_t crc32;
+    uint16_t major_version;
+    uint16_t minor_version;
+    CommandCode command_code;
+    uint16_t data_length;
+} RadioHeader;
+assert_size(RadioHeader, 12);
+
+typedef union RadioData {
+    HelloRequest hello_request;
+    HelloResponse hello_response;
+    BasicControl control;
+    BasicTelemetry telemetry;
+} RadioData;
+assert_size(RadioData, 40);
+
+// TODO: remove me
 typedef struct RadioPacket {
     uint32_t crc32;
     uint16_t major_version;

--- a/ateam-common-packets/rust-lib/Cargo.lock
+++ b/ateam-common-packets/rust-lib/Cargo.lock
@@ -16,6 +16,7 @@ name = "ateam-common-packets"
 version = "1.0.0"
 dependencies = [
  "bindgen",
+ "which",
 ]
 
 [[package]]
@@ -230,6 +231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,13 +324,13 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/ateam-common-packets/rust-lib/Cargo.toml
+++ b/ateam-common-packets/rust-lib/Cargo.toml
@@ -10,3 +10,4 @@ path = "src/lib.rs"
 
 [build-dependencies]
 bindgen = "0.60.1"
+which = "4.4.0"

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -7,7 +7,9 @@ use bindgen::EnumVariation;
 extern crate which;
 use which::which;
 
-fn is_arm_none_eabi_sysroot_valid(sysroot: impl AsRef<Path> + std::convert::AsRef<std::ffi::OsStr>) -> bool {
+fn is_arm_none_eabi_sysroot_valid(
+    sysroot: impl AsRef<Path> + std::convert::AsRef<std::ffi::OsStr>,
+) -> bool {
     let sysroot_include = Path::new(&sysroot).join("arm-none-eabi/include");
     if !sysroot_include.exists() {
         eprintln!("the sysroot does not exist, or is malformed because it does not contain the header include folder");
@@ -22,7 +24,9 @@ fn is_arm_none_eabi_sysroot_valid(sysroot: impl AsRef<Path> + std::convert::AsRe
 
     let types_header = Path::new(&sysroot_include).join("machine/_types.h");
     if !types_header.exists() {
-        eprintln!("the include root appears malformed because it does not contain machine/_types.h");
+        eprintln!(
+            "the include root appears malformed because it does not contain machine/_types.h"
+        );
         return false;
     }
 
@@ -31,7 +35,10 @@ fn is_arm_none_eabi_sysroot_valid(sysroot: impl AsRef<Path> + std::convert::AsRe
 
 fn find_gcc_arm_embedded_sysroot() -> PathBuf {
     if let Some(user_specified_root) = env::var_os("ARM_NONE_EABI_ROOT") {
-        println!("user specified a embedded sysroot via $ARM_NONE_EABI_ROOT={:?}", user_specified_root);
+        println!(
+            "user specified a embedded sysroot via $ARM_NONE_EABI_ROOT={:?}",
+            user_specified_root
+        );
         if is_arm_none_eabi_sysroot_valid(user_specified_root.clone()) {
             println!("OK. the specified root appears valid.");
             return PathBuf::from(user_specified_root);
@@ -54,15 +61,17 @@ fn find_gcc_arm_embedded_sysroot() -> PathBuf {
         println!("arm-none-eabi-gcc not on the path.");
     }
 
-    panic!("exhausted all options to find arm-none-eabi sysroot for bindgen. 
+    panic!(
+        "exhausted all options to find arm-none-eabi sysroot for bindgen. 
         Ensure arm-none-eabi-gcc is on the path and fully installed, 
-        or manually set $ARM_NONE_EABI_ROOT in the environment.");
+        or manually set $ARM_NONE_EABI_ROOT in the environment."
+    );
 }
 
 fn create_configured_builder() -> bindgen::Builder {
     let mut sysroot = find_gcc_arm_embedded_sysroot();
     sysroot.push("arm-none-eabi/include/");
-    
+
     let bindings = bindgen::Builder::default()
         // Tell bindgen to use core instead of std
         // this will target embedded, so we don't have std

--- a/ateam-common-packets/rust-lib/build.rs
+++ b/ateam-common-packets/rust-lib/build.rs
@@ -1,48 +1,78 @@
 extern crate bindgen;
 use bindgen::EnumVariation;
-use std::path::Path;
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn find_gcc_arm_embedded_incroot() -> PathBuf {
+    let arm_none_eabi_root = env::var_os("ARM_NONE_EABI_ROOT").expect(
+        "the ABI definition root was not set.
+        Are you in the Nix environment?
+        Set \"$ARM_NONE_EABI_ROOT=<root of arm-none-eabi-gcc>\"",
+    );
+
+    let sysroot_include = Path::new(&arm_none_eabi_root).join("arm-none-eabi/include");
+    if !sysroot_include.exists() {
+        panic!("the sysroot does not exist, or is malformed because it does not contain the header include folder");
+    }
+
+    let cdefs_header = Path::new(&sysroot_include).join("sys/cdefs.h");
+    if !cdefs_header.exists() {
+        panic!("the include root appears malformed because it does not contain sys/cdefs.h");
+    }
+
+    let types_header = Path::new(&sysroot_include).join("machine/_types.h");
+    if !types_header.exists() {
+        panic!("the include root appears malformed because it does not contain machine/_types.h");
+    }
+
+    sysroot_include.to_path_buf()
+}
+
+fn create_configured_builder() -> bindgen::Builder {
+    let incroot = find_gcc_arm_embedded_incroot();
+
+    let bindings = bindgen::Builder::default()
+        // Tell bindgen to use core instead of std
+        // this will target embedded, so we don't have std
+        .use_core()
+        .ctypes_prefix("::core::ffi")
+        // tell clang where to include system definitions
+        .clang_arg("-target")
+        .clang_arg(std::env::var("TARGET").unwrap())
+        .clang_arg(format!("-I{}", incroot.to_str().unwrap()))
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Put enum consts in module
+        .default_enum_style(EnumVariation::ModuleConsts)
+        .generate_comments(true);
+
+    bindings
+}
 
 fn main() {
     // Tell cargo to invalidate the built crate whenever the sources change
     println!("cargo:rerun-if-changed=../include/");
 
-    let bindings_stspin = bindgen::Builder::default()
+    let bindings_stspin = create_configured_builder()
         // The input header we would like to generate
         // bindings for.
         .header("../include/stspin.h")
         .allowlist_file(".*/stspin.h")
-        // Tell bindgen to use core instead of std
-        .use_core()
-        .ctypes_prefix("::core::ffi")
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        // Put enum consts in module
-        .default_enum_style(EnumVariation::ModuleConsts)
-        // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate STSPIN bindings");
 
-    let bindings_kicker = bindgen::Builder::default()
+    let bindings_kicker = create_configured_builder()
         // The input header we would like to generate
         // bindings for.
         .header("../include/kicker.h")
         .allowlist_file(".*/kicker.h")
-        // Tell bindgen to use core instead of std
-        .use_core()
-        .ctypes_prefix("::core::ffi")
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        // Put enum consts in module
-        .default_enum_style(EnumVariation::ModuleConsts)
-        // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate Kicker bindings");
 
-    let bindings_radio = bindgen::Builder::default()
+    let bindings_radio = create_configured_builder()
         // The input header we would like to generate
         // bindings for.
         .header("../include/basic_control.h")
@@ -53,22 +83,11 @@ fn main() {
         .allowlist_file(".*/basic_telemetry.h")
         .allowlist_file(".*/hello_data.h")
         .allowlist_file(".*/radio.h")
-        .generate_comments(true)
-        // Tell bindgen to use core instead of std
-        .use_core()
-        .ctypes_prefix("::core::ffi")
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        // Put enum consts in module
-        .default_enum_style(EnumVariation::ModuleConsts)
-        // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate Radio bindings");
 
     // Write the bindings to the lib source dir
-    // let out_dir = env::var_os("OUT_DIR").unwrap();
     let out_dir = "src";
     bindings_stspin
         .write_to_file(Path::new(&out_dir).join("bindings_stspin.rs"))

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -16,12 +19,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -32,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678314140,
-        "narHash": "sha256-B91P+zQbxc0vi72cexRbcaYak00qVGtEbiRnmfG/mdI=",
+        "lastModified": 1689726558,
+        "narHash": "sha256-QPVY1u0n+ErmldYcn5DaIYMqn1L3dGETdm94KwKJU9s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "94c379180a50d0e915bb49a9d567ecc4d3fb548b",
+        "rev": "43e13111c6803551751d76a8adb9472f6f14f9c8",
         "type": "github"
       },
       "original": {
@@ -47,11 +53,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
         "type": "github"
       },
       "original": {
@@ -74,16 +80,46 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1678242776,
-        "narHash": "sha256-36K1Rg2vM+NLqORSBL4e3aZHmgkb6aS9upHsuG4Akns=",
+        "lastModified": 1689647697,
+        "narHash": "sha256-8ZX/DVpKLmr85FRKILb+2p+JuxfLQ49LjXG/gmwsoIU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ea311f10a5d51e7588799281bab0556b4e978d00",
+        "rev": "ed2774a9131ddad12e552ba04bd92f87df04a28b",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
           # needed by bindgen to invoke clang
           shellHook = ''
           export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
-          export ARM_NONE_EABI_ROOT="$(realpath $(dirname $(which arm-none-eabi-gcc))/..)"
           '';
 
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           # needed by bindgen to invoke clang
           shellHook = ''
           export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
+          export ARM_NONE_EABI_ROOT="$(realpath $(dirname $(which arm-none-eabi-gcc))/..)"
           '';
 
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -25,18 +25,27 @@
 
       in {
         devShell = pkgs.mkShell {
-          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang}/lib/libclang.so";
-
+          # needed by bindgen to invoke clang
           shellHook = ''
           export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
           '';
 
           buildInputs = with pkgs; [
             gnumake
+
+            # GCC ARM Embedded 10 provides the sysroot/ABI defining types and type sizes
+            # for bindgen
+            gcc-arm-embedded-12
+
+            # needed by bindgen
             clang
 
             # Rust Embedded
-            rust-bin.nightly.latest.default
+            (rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
+              extensions = [ "rust-src" ];
+              targets = [ "thumbv7em-none-eabihf" "thumbv6m-none-eabi" ];
+            }))
+            rust-analyzer
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           buildInputs = with pkgs; [
             gnumake
 
-            # GCC ARM Embedded 10 provides the sysroot/ABI defining types and type sizes
+            # GCC ARM Embedded 12 provides the sysroot/ABI defining types and type sizes
             # for bindgen
             gcc-arm-embedded-12
 
@@ -48,6 +48,7 @@
             }))
             rust-analyzer
           ];
+
         };
       }
     );


### PR DESCRIPTION
Burndown List

- [x] cleanup build.rs
- [x] make build.rs explicitly search for and only include/link a arm-none-eabi sysroot. This is currently broken blatantly on Mac and probably Linux too 
- [x] add CI cron for all nightlies
- [ ] make all fields clearly distinguished as nouns, not verbs, as bindgen generated functions become ambiguous